### PR TITLE
Update ZettelkastenUtilities.ts

### DIFF
--- a/src/ZettelkastenUtilities.ts
+++ b/src/ZettelkastenUtilities.ts
@@ -6,7 +6,7 @@ export default class ZettelkastenUtilities {
     const padNumber = (val: number, len: number) => val.toString().padStart(len, '0');
     const id = [
       padNumber(date.getFullYear(), 4),
-      padNumber(date.getMonth(), 2),
+      padNumber(date.getMonth() + 1, 2),
       padNumber(date.getDate(), 2),
       padNumber(date.getHours(), 2),
       padNumber(date.getMinutes(), 2),


### PR DESCRIPTION
The getMonth() method returns the month as a zero-based value (January is 0, December is 11) so adding 1 to get the proper month number.