### PR TITLE
Human readable month numbers

### DIFF
--- a/src/ZettelkastenUtilities.ts
+++ b/src/ZettelkastenUtilities.ts
@@ -6,7 +6,7 @@ export default class ZettelkastenUtilities {
     const padNumber = (val: number, len: number) => val.toString().padStart(len, '0');
     const id = [
       padNumber(date.getFullYear(), 4),
-      padNumber(date.getMonth(), 2),
+      padNumber(date.getMonth()+1, 2),
       padNumber(date.getDate(), 2),
       padNumber(date.getHours(), 2),
       padNumber(date.getMinutes(), 2),


### PR DESCRIPTION
date.getMonth() is 0 based.
ISO formatting and humans better understand the 1-based month indexing.

This makes the extension also more compatible with other zettelkast systems (e.g. obsidian)